### PR TITLE
Use FilePath instead of Text for MetaInfo

### DIFF
--- a/src/Haze/MetaInfo.hs
+++ b/src/Haze/MetaInfo.hs
@@ -22,6 +22,7 @@ where
 
 import Relude
 
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.HashMap.Strict as HM
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
@@ -61,9 +62,9 @@ the single file.
 -}
 data FileInfo 
     -- | A single file, with name, length, and md5 sum
-    = SingleFile Text Int64 (Maybe MD5Sum)
+    = SingleFile FilePath Int64 (Maybe MD5Sum)
     -- | Multiple files, with directory name
-    |  MultiFile Text [FileItem]
+    |  MultiFile FilePath [FileItem]
     deriving (Show)
 
 {- | A single file in a multi file torrent
@@ -73,7 +74,7 @@ from the 'SingleFile' branch of 'FileInfo'. Notably, instead of
 having a name, it instead has a list of strings representing
 the full file path, which must be respected.
 -}
-data FileItem = FileItem [Text] Int64 (Maybe MD5Sum) deriving (Show)
+data FileItem = FileItem [FilePath] Int64 (Maybe MD5Sum) deriving (Show)
 
 {- | Represents the information in a .torrent file
 stem.Directory
@@ -132,6 +133,8 @@ decodeMeta = Decoder doDecode
     tryBS _            = Nothing
     tryText :: Bencoding -> Maybe Text
     tryText = fmap decodeUtf8 . tryBS
+    tryPath :: Bencoding -> Maybe FilePath
+    tryPath = fmap BS.unpack . tryBS
     tryList :: Bencoding -> Maybe [Bencoding]
     tryList (BList l) = Just l
     tryList _         = Nothing
@@ -165,12 +168,12 @@ decodeMeta = Decoder doDecode
         return (len, md5)
     getSingle :: BenMap -> Maybe FileInfo
     getSingle mp = do
-        name <- withKey "name" mp tryText
+        name <- withKey "name" mp tryPath
         (len, md5) <- getFilePart mp
         return (SingleFile name len md5)
     getMulti :: BenMap -> Bencoding -> Maybe FileInfo
     getMulti mp (BList l) = do
-        name  <- withKey "name" mp tryText
+        name  <- withKey "name" mp tryPath
         files <- traverse getFileItem l
         return (MultiFile name files)
     getMulti _ _         = Nothing
@@ -178,6 +181,6 @@ decodeMeta = Decoder doDecode
     getFileItem (BMap mp) = do
         (len, md5) <- getFilePart mp
         path <- withKey "path" mp 
-                (traverse tryText <=< tryList)
+                (traverse tryPath <=< tryList)
         return (FileItem path len md5)
     getFileItem _         = Nothing


### PR DESCRIPTION
Resolves #9 

This makes it much clearer what is and isn't a path when looking at the MetaInfo structure