### PR TITLE
Add the ability to decode announce info

### DIFF
--- a/haze.cabal
+++ b/haze.cabal
@@ -29,6 +29,7 @@ library
   build-depends:       base-noprelude       >= 4.11 && < 5
                      , attoparsec           >= 0.13 && < 0.14
                      , bytestring           >= 0.10 && < 0.11
+                     , network              >= 2.6  && < 2.7
                      , relude               >= 0.4  && < 0.5
                      , text                 >= 1.2  && < 1.3
                      , time                 >= 1.8  && < 1.9

--- a/haze.cabal
+++ b/haze.cabal
@@ -24,7 +24,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Haze
                        Haze.Bencoding
-                       Haze.MetaInfo
+                       Haze.Tracker
   ghc-options:         -Wall
   build-depends:       base-noprelude       >= 4.11 && < 5
                      , attoparsec           >= 0.13 && < 0.14

--- a/src/Haze/Tracker.hs
+++ b/src/Haze/Tracker.hs
@@ -17,6 +17,11 @@ module Haze.Tracker
     , MetaInfo(..)
     , decodeMeta
     , metaFromBytes
+    , Announce(..)
+    , AnnounceInfo(..)
+    , Peer(..)
+    , decodeAnnounce
+    , announceFromHTTP
     )
 where
 
@@ -201,6 +206,17 @@ data Peer = Peer
     , peerPort :: PortNumber
     }
 
+{- | This reads a bytestring announce from HTTP
+
+HTTP and UDP trackers differ in that HTTP trackers
+will send back a bencoded bytestring to read the
+announce information from, but UDP trackers will
+send a bytestring without bencoding.
+This parses the bencoded bytestring from HTTP.
+-}
+announceFromHTTP :: ByteString -> Either DecodeError Announce
+announceFromHTTP bs = decode decodeAnnounce bs
+    >>= maybe (Left (DecodeError "Bad Announce Data")) Right
 
 -- | A Bencoding decoder for the Announce data
 decodeAnnounce :: Decoder (Maybe Announce)

--- a/src/Haze/Tracker.hs
+++ b/src/Haze/Tracker.hs
@@ -255,7 +255,6 @@ decodeAnnounce = Decoder doDecode
             peerPort <- withKey "port" mp tryNum
             return (Peer {..})
         getPeer _          = Nothing
-    dictpeers _         = Nothing
     binPeers :: Bencoding -> Maybe [Peer]
     binPeers (BString bs)
         -- The bytestring isn't a multiple of 6

--- a/src/Haze/Tracker.hs
+++ b/src/Haze/Tracker.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE RecordWildCards #-}
 {- |
-Description: Contains functions for parsing .torrent files
+Description: Contains functions related to trackers
 
-Each .torrent file is a MetaInfo file, containing
-information about the files in the torrent. This module
-exports data structure and functions to read and operate
-on these files.
+This file provides a more abstract description of
+the communication protocol with trackers. First it
+specificies the data in a .torrent file with MetaInfo,
+then data sent to and returned from a tracker.
 -}
-module Haze.MetaInfo 
+module Haze.Tracker 
     ( Tracker(..)
     , TieredList(..)
     , MD5Sum(..)


### PR DESCRIPTION
resolves #8

This adds the core structures related to the announce file, without support for the specific
protocol used by UDP trackers. That would be the next thing to add.