### PR TITLE
Disconnect from trackers when errors occurr

### DIFF
--- a/haze.cabal
+++ b/haze.cabal
@@ -37,6 +37,8 @@ library
                      , http-types           >= 0.12 && < 0.13
                      , network              >= 2.6  && < 2.7
                      , relude               >= 0.4  && < 0.5
+                     , safe-exceptions      >= 0.1  && < 0.2
+                     , stm                  >= 2.4  && < 2.5
                      , text                 >= 1.2  && < 1.3
                      , time                 >= 1.8  && < 1.9
                      , unordered-containers >= 0.2  && < 0.3

--- a/haze.cabal
+++ b/haze.cabal
@@ -31,6 +31,7 @@ library
   ghc-options:         -Wall
   build-depends:       base-noprelude       >= 4.11 && < 5
                      , attoparsec           >= 0.13 && < 0.14
+                     , async                >= 2.2  && < 2.3
                      , bytestring           >= 0.10 && < 0.11
                      , cryptohash-sha1      >= 0.11 && < 0.12
                      , http-client          >= 0.5  && < 0.6

--- a/src/Haze/Client.hs
+++ b/src/Haze/Client.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
 {- | 
 Description: contains functions for interacting with a tracker
 
@@ -11,7 +13,10 @@ where
 
 import Relude
 
-import Control.Exception.Safe (bracket)
+import Control.Concurrent.Async (Async, async, cancel, link)
+import Control.Exception.Safe (
+    MonadThrow, MonadCatch, MonadMask,
+    Exception, bracket, throw)
 import Data.Attoparsec.ByteString as AP
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -22,11 +27,11 @@ import Network.Socket.ByteString (sendAllTo, recv)
 
 
 import Haze.Bencoding (DecodeError(..))
-import Haze.Tracker (Tracker(..), MetaInfo(..), metaFromBytes,
-                     newTrackerRequest, 
-                     trackerQuery, announceFromHTTP,
-                     parseUDPConn, parseUDPAnnounce,
-                     newUDPRequest, encodeUDPRequest)
+import Haze.Tracker (
+    Tracker(..), MetaInfo(..), Announce(..), AnnounceInfo(..), 
+    metaFromBytes, newTrackerRequest, trackerQuery,
+    announceFromHTTP, parseUDPConn, parseUDPAnnounce,
+    newUDPRequest, encodeUDPRequest)
 
 
 {- | Generates a peer id from scratch.
@@ -37,8 +42,8 @@ a tracker, and not at every interaction with the tracker.
 Uses the Azureus style id, with HZ as the prefix, and then appends
 a UTC timestamp, before then taking only the first 20 bytes.
 -}
-generatePeerID :: IO ByteString
-generatePeerID = do
+generatePeerID :: MonadIO m => m ByteString
+generatePeerID = liftIO $ do
     secs <- utctDayTime <$> getCurrentTime
     let whole = "-HZ010-" <> show secs
         cut = BS.take 20 whole
@@ -52,29 +57,149 @@ launchClient file = do
         Left (DecodeError err) -> do
             putStrLn "Failed to decode file:"
             putTextLn err
-        Right meta -> launchTorrent meta
+        Right meta -> do
+            clientInfo <- newClientInfo meta
+            runClientM launchTorrent clientInfo
 
 
-launchTorrent :: MetaInfo -> IO ()
-launchTorrent torrent = do
+-- | Represents errors that can happen with a tracker
+data TrackerError
+    -- | A malformatted packet was sent to the client
+    = TrackerParseErr Text
+    -- | The tracker sent an incorrect transaction ID
+    | TrackerTransactionErr
+    deriving (Show)
+
+-- | This will get thrown because of a programmer error
+data BadAnnounceException = BadAnnounceException Text
+    deriving (Show)
+instance Exception BadAnnounceException
+
+type ConnMessage = Either TrackerError AnnounceInfo
+
+{- | Represents the state of the client
+
+Note that this is the state of the
+entire client, and not a connection to
+a tracker.
+
+An MVar is fine for communication here, since
+the parent thread is always waiting for
+a message from the tracker connection, and the
+tracker connection's messages are always spaced far
+enough away to give us time to launch other things
+in reaction to a message.
+-}
+data ClientInfo = ClientInfo
+    { clientTorrent :: MetaInfo
+    -- | Used to communicate with the tracker connections
+    , clientMsg :: MVar ConnMessage
+    }
+
+{- | Make a ClientInfo from a torrent with an empty Queue
+
+The default queue size here is 16, which should be more
+than sufficient, since we only ever expect one message
+to be sent, and we're always waiting    
+-}
+newClientInfo :: MetaInfo -> IO ClientInfo
+newClientInfo torrent = 
+    ClientInfo torrent <$> newEmptyMVar
+
+-- | Represents a global torrent client
+newtype ClientM a = ClientM (ReaderT ClientInfo IO a)
+    deriving ( Functor, Applicative, Monad
+             , MonadReader ClientInfo, MonadIO
+             )
+
+-- | Runs a global client
+runClientM :: ClientM a -> ClientInfo -> IO a
+runClientM (ClientM m) = runReaderT m
+
+
+-- | Wait for the connection message
+readConn :: ClientM ConnMessage
+readConn =
+    liftIO . takeMVar =<< asks clientMsg
+    
+-- | Return Nothing if no message is immediately available
+tryReadConn :: ClientM (Maybe ConnMessage)
+tryReadConn = 
+    liftIO . tryTakeMVar =<< asks clientMsg 
+
+
+
+launchTorrent :: ClientM ()
+launchTorrent = do
     peerID <- generatePeerID
-    case metaAnnounce torrent of
-        HTTPTracker url -> connectHTTP peerID torrent url
+    ClientInfo{..} <- ask
+    let connInfo = ConnInfo peerID clientTorrent clientMsg
+    thread <- case metaAnnounce clientTorrent of
+        HTTPTracker url -> 
+            launchAsync . runConnWith connInfo $
+            connectHTTP url
         UDPTracker url prt -> 
-            Sock.withSocketsDo $
-            connectUDP peerID torrent url prt
+            launchAsync . Sock.withSocketsDo . runConnWith connInfo $
+            connectUDP url prt
+    ann <- readConn
+    print ann
+    liftIO $ cancel thread
+  where
+    launchAsync :: MonadIO m => IO () -> m (Async ())
+    launchAsync m = liftIO $ do
+        a <- async m
+        link a
+        return a
 
-connectHTTP :: ByteString -> MetaInfo -> Text -> IO ()
-connectHTTP peerID torrent url = do
-    mgr <- newManager defaultManagerSettings
-    request <- parseRequest (toString url)
-    let trackerReq = newTrackerRequest torrent peerID
+
+-- | The information a connection to a tracker needs
+data ConnInfo = ConnInfo
+    { connPeerID :: ByteString
+    , connTorrent :: MetaInfo
+    , connMsg :: MVar ConnMessage
+    }
+
+
+newtype ConnM a = ConnM (ReaderT ConnInfo IO a)
+    deriving ( Functor, Applicative, Monad
+             , MonadReader ConnInfo, MonadIO
+             , MonadThrow, MonadCatch, MonadMask
+             )
+
+-- | Start a connection with certain information
+runConnWith :: ConnInfo -> ConnM a -> IO a
+runConnWith info (ConnM m) = runReaderT m info
+
+{- | Send the information in an announce, or fail
+
+Since bad announces are usually our fault, we want
+to throw an exception
+-}
+putAnnounce :: Either TrackerError Announce -> ConnM ()
+putAnnounce (Left err) = do
+    mvar <- asks connMsg
+    putMVar mvar (Left err)
+putAnnounce (Right (FailedAnnounce t)) = 
+    liftIO (throw (BadAnnounceException t))
+putAnnounce (Right (GoodAnnounce info)) = do
+    mvar <- asks connMsg
+    putMVar mvar (Right info)
+
+
+connectHTTP :: Text -> ConnM ()
+connectHTTP url = do
+    ConnInfo{..} <- ask
+    mgr <- liftIO $ newManager defaultManagerSettings
+    request <- liftIO $ parseRequest (toString url)
+    let trackerReq = newTrackerRequest connTorrent connPeerID
         query = trackerQuery trackerReq
     let withQuery = setQueryString query request
-    response <- httpLbs withQuery mgr
+    response <- liftIO $ httpLbs withQuery mgr
     let bytes = LBS.toStrict $ responseBody response
-        announce = announceFromHTTP bytes
-    print announce
+        announce = case announceFromHTTP bytes of
+            Left (DecodeError err) -> Left (TrackerParseErr err)
+            Right info             -> Right info
+    putAnnounce announce
 
 
 -- | Represents a UDP connection to some tracker
@@ -82,20 +207,22 @@ data UDPSocket = UDPSocket Sock.Socket Sock.SockAddr
 
 
 -- | Connect to a UDP tracker with url and port
-connectUDP :: ByteString -> MetaInfo -> Text -> Text -> IO ()
-connectUDP peerID torrent url prt = do
-    bracket (makeUDPSocket url prt) closeUDPSocket $ \udp -> do
-        initiate udp
+connectUDP :: Text -> Text -> ConnM ()
+connectUDP url' prt' = do
+    ConnInfo{..} <- ask
+    bracket (makeUDPSocket url' prt') closeUDPSocket $ \udp -> do
+        initiate connPeerID udp
         connBytes <- recvUDP udp 1024
-        connInfo <- parseFail parseUDPConn connBytes
-        let request = newUDPRequest torrent peerID connInfo
-        sendUDP udp (encodeUDPRequest request)
-        annBytes <- recvUDP udp 1024
-        announce <- parseFail parseUDPAnnounce annBytes
-        print announce
+        announce <- runExceptT $ do
+            connInfo <- parseFail parseUDPConn connBytes
+            let request = newUDPRequest connTorrent connPeerID connInfo
+            sendUDP udp (encodeUDPRequest request)
+            annBytes <- recvUDP udp 1024
+            parseFail parseUDPAnnounce annBytes
+        putAnnounce announce
   where
-    makeUDPSocket :: Text -> Text -> IO UDPSocket
-    makeUDPSocket url prt = do
+    makeUDPSocket :: MonadIO m => Text -> Text -> m UDPSocket
+    makeUDPSocket url prt = liftIO $ do
         let urlS =  toString url
             portS = toString prt
             hints = Just Sock.defaultHints
@@ -106,22 +233,22 @@ connectUDP peerID torrent url prt = do
             addr = Sock.addrAddress target
         sock <- Sock.socket fam Sock.Datagram Sock.defaultProtocol
         return (UDPSocket sock addr)
-    closeUDPSocket :: UDPSocket -> IO ()
-    closeUDPSocket (UDPSocket sock _) = Sock.close sock
-    recvUDP :: UDPSocket -> Int -> IO ByteString
-    recvUDP (UDPSocket sock _) amount = recv sock amount
-    sendUDP :: UDPSocket -> ByteString -> IO ()
-    sendUDP (UDPSocket sock addr ) bytes = 
+    closeUDPSocket :: MonadIO m => UDPSocket -> m ()
+    closeUDPSocket (UDPSocket sock _) = liftIO $ Sock.close sock
+    recvUDP :: MonadIO m => UDPSocket -> Int -> m ByteString
+    recvUDP (UDPSocket sock _) amount = liftIO $ recv sock amount
+    sendUDP :: MonadIO m => UDPSocket -> ByteString -> m ()
+    sendUDP (UDPSocket sock addr ) bytes = liftIO $
         sendAllTo sock bytes addr
-    initiate :: UDPSocket -> IO ()
-    initiate udp = sendUDP udp $
+    initiate :: MonadIO m => ByteString -> UDPSocket -> m ()
+    initiate peerID udp = sendUDP udp $
       "\0\0\4\x17\x27\x10\x19\x80"
       <> "\0\0\0\0"
       -- This should be sufficiently unique
       <> BS.drop 16 peerID
 
-parseFail :: MonadFail m => AP.Parser a -> ByteString -> m a
-parseFail parser bs =
+parseFail :: Monad m => AP.Parser a -> ByteString -> ExceptT TrackerError m a
+parseFail parser bs = ExceptT . return $
     case AP.parseOnly parser bs of
-        Left s  -> fail s
-        Right a -> return a
+        Left s  -> Left (TrackerParseErr (fromString s))
+        Right a -> Right a

--- a/src/Haze/Client.hs
+++ b/src/Haze/Client.hs
@@ -142,8 +142,12 @@ launchTorrent = do
             launchAsync . Sock.withSocketsDo . runConnWith connInfo $
             connectUDP url prt
     ann <- readConn
-    print ann
-    liftIO $ cancel thread
+    case ann of
+        Right info -> print info
+        Left err   -> do
+            putTextLn "Disconnecting from bad tracker:"
+            print err
+            liftIO $ cancel thread
   where
     launchAsync :: MonadIO m => IO () -> m (Async ())
     launchAsync m = liftIO $ do


### PR DESCRIPTION
resolves #28

This makes the interaction between the client and the tracker more concurrent, which should make
fixing the other issues much easier as well. This uses an MVar to communicate between the Connections and the global client, from which the client reads. When the client reads a handleable error, they disconnect from that tracker, by killing the connection.

There's no logic at the moment to switch to the next priority tracker. That should be taken care of when resolving #29, which needs to do tracker switching anyways.