### PR TITLE
Add listening port to CLI conf

### DIFF
--- a/src/Haze/Config.hs
+++ b/src/Haze/Config.hs
@@ -7,6 +7,7 @@ as well as utilities for parsing that config from the command line.
 -}
 module Haze.Config
     ( Config(..)
+    , Port(..)
     , parseConfig
     )
 where
@@ -36,9 +37,12 @@ data Config = Config
     at all.
     -}
     , configLogFile :: !(Maybe (Path Abs File))
+    -- | The port to listen or incoming connections on.
+    , configPort :: !Port
     }
     deriving (Show)
 
+newtype Port = Port Int deriving (Show, Read)
 
 -- | Read an absolute directory given a root for relative directories
 rootedDir :: Path Abs Dir -> ReadM (Path Abs Dir)
@@ -77,6 +81,15 @@ configParser root =
                 <> help "Logging will happen to this file if set"
                 <> value Nothing
                 )
+        <*> (Port <$>
+              option
+                auto
+                (  metavar "PORT"
+                <> long "port"
+                <> short 'p'
+                <> help "The port to listen for incoming connections on"
+                <> value 6881
+                ))
 
 version :: Parser (a -> a)
 version = infoOption

--- a/src/Haze/Tracker.hs
+++ b/src/Haze/Tracker.hs
@@ -93,6 +93,7 @@ import           Haze.Bits                      ( Bits
                                                 , packBytes
                                                 , parseInt
                                                 )
+import           Haze.Config                    ( Port(..) )
 
 
 {- | Represents the URL for a torrent Tracker
@@ -346,11 +347,11 @@ data TrackerRequest = TrackerRequest
     deriving (Show)
 
 -- | Constructs the tracker request to be used at the start of a session
-newTrackerRequest :: MetaInfo -> ByteString -> TrackerRequest
-newTrackerRequest meta@MetaInfo {..} peerID = TrackerRequest
+newTrackerRequest :: Port -> MetaInfo -> ByteString -> TrackerRequest
+newTrackerRequest (Port port) meta@MetaInfo {..} peerID = TrackerRequest
     metaInfoHash
     peerID
-    6881
+    (fromIntegral port)
     (firstTrackStatus meta)
     True
     ReqStarted
@@ -407,9 +408,9 @@ data UDPTrackerRequest =
     UDPTrackerRequest ByteString TrackerRequest
 
 -- | Construct a new UDP request.
-newUDPRequest :: MetaInfo -> ByteString -> UDPConnection -> UDPTrackerRequest
-newUDPRequest meta peerID (UDPConnection trans conn) =
-    let trackerReq = newTrackerRequest meta peerID
+newUDPRequest :: Port -> MetaInfo -> ByteString -> UDPConnection -> UDPTrackerRequest
+newUDPRequest port meta peerID (UDPConnection trans conn) =
+    let trackerReq = newTrackerRequest port meta peerID
         withTrans  = trackerReq { treqTransactionID = Just trans }
     in  UDPTrackerRequest conn withTrans
 
@@ -453,7 +454,7 @@ encodeUDPRequest (UDPTrackerRequest conn TrackerRequest {..}) =
     pack32 :: (Bits i, Integral i) => i -> ByteString
     pack32 = BS.pack . encodeIntegralN 4
     packPort :: PortNumber -> ByteString
-    packPort p = BS.drop 2 (pack32 ((fromIntegral p) :: Int))
+    packPort p = BS.drop 2 (pack32 (fromIntegral p :: Int))
     eventNum :: Int32
     eventNum = case treqEvent of
         ReqEmpty     -> 0


### PR DESCRIPTION
I wanted to have the app be able to run on any given listening port, so I added it to the CLI params + the different app states. Unfortunately a lot of them are spread out and there was no unified state to sort of stuff it in.

I didn't want to really make too many invasive changes and trying to make a unified env type to add more `ReaderT` or something seemed like too much.

The change seems to work as indended:

```bash
$ lsof -i | grep haze
haze      25786 gonz   41u  IPv6 31932501      0t0  TCP *:6882 (LISTEN)
```
And in the log:
```
[Info 2019-05-03 18:16:45.969523937 UTC], source: "gateway", gateway-listening: 6882
```

What do you think?